### PR TITLE
Add TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,63 @@
+import * as React from "react";
+import { StyledComponentClass } from "styled-components";
+
+declare type Diff<T extends string, U extends string> = ({ [P in T]: P } &
+  { [P in U]: never } & { [x: string]: never })[T];
+declare type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+
+declare module "grid-styled" {
+  type ResponsiveProp = number | string | number[] | string[];
+
+  interface CommonProps {
+    width: ResponsiveProp;
+    fontSize: ResponsiveProp;
+    color: ResponsiveProp;
+    bg: ResponsiveProp;
+    m: ResponsiveProp;
+    mt: ResponsiveProp;
+    mr: ResponsiveProp;
+    mb: ResponsiveProp;
+    ml: ResponsiveProp;
+    mx: ResponsiveProp;
+    my: ResponsiveProp;
+    p: ResponsiveProp;
+    pt: ResponsiveProp;
+    pr: ResponsiveProp;
+    pb: ResponsiveProp;
+    pl: ResponsiveProp;
+    px: ResponsiveProp;
+    py: ResponsiveProp;
+  }
+
+  interface BoxProps
+    extends Omit<React.HTMLProps<HTMLDivElement>, "width" | "wrap" | "is"> {
+    flex: ResponsiveProp;
+    order: ResponsiveProp;
+    is: string | React.ComponentClass<any>;
+  }
+
+  interface FlexProps extends BoxProps {
+    wrap: ResponsiveProp | boolean;
+    direction: ResponsiveProp | boolean;
+    align: ResponsiveProp | boolean;
+    justify: ResponsiveProp | boolean;
+    column: boolean;
+  }
+
+  type BoxComponent = StyledComponentClass<
+    Partial<CommonProps & BoxProps>,
+    any
+  >;
+  type FlexComponent = StyledComponentClass<
+    Partial<CommonProps & FlexProps>,
+    any
+  >;
+
+  export const Box: BoxComponent;
+  export const Flex: FlexComponent;
+  export const Grid: BoxComponent;
+  export const Golden: BoxComponent;
+  export const Half: BoxComponent;
+  export const Third: BoxComponent;
+  export const Quarter: BoxComponent;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0-11",
   "description": "Responsive React grid system built with styled-components",
   "main": "dist/index.js",
+  "typings": "index.d.ts",
   "scripts": {
     "prepublish": "babel src -d dist",
     "test": "nyc ava",
@@ -23,6 +24,7 @@
   "author": "Brent Jackson",
   "license": "MIT",
   "devDependencies": {
+    "@types/react": "^15.0.37",
     "ava": "^0.22.0",
     "babel-cli": "^6.26.0",
     "babel-loader": "^7.1.2",


### PR DESCRIPTION
As mentioned in #26. Uses mapped types for `Omit` so TS support is >= 2.4.