### PR TITLE
Move dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,11 +47,13 @@
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.1"
   },
-  "peerDependencies": {
+  "dependencies": {
     "prop-types": "^15.6.0",
-    "styled-components": "^2.2.0",
     "styled-system": "^1.0.2",
     "tag-hoc": "^1.0.0"
+  },
+  "peerDependencies": {
+    "styled-components": "^2.0.0",
   },
   "ava": {
     "require": [

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "tag-hoc": "^1.0.0"
   },
   "peerDependencies": {
-    "styled-components": "^2.0.0",
+    "styled-components": "^2.0.0"
   },
   "ava": {
     "require": [

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.1"
   },
-  "dependencies": {
+  "peerDependencies": {
     "prop-types": "^15.6.0",
     "styled-components": "^2.2.0",
     "styled-system": "^1.0.2",


### PR DESCRIPTION
To prevent shipping all the required dependencies and bloating consumers with different versions of all the dependencies, move the required dependencies to `peerDependencies`.

Basically defining the dependencies like styled-components in the dependencies object will require everyone to install a certain version of styled-components even though a consumer may already have a different version installed which suffices, this prevents that from happening.