### PR TITLE
Fixed issue with Flex prop types

### DIFF
--- a/src/Flex.js
+++ b/src/Flex.js
@@ -21,7 +21,8 @@ Flex.propTypes = {
   ...propTypes.flexWrap,
   ...propTypes.flexDirection,
   ...propTypes.alignItems,
-  ...propTypes.justifyContent
+  ...propTypes.justifyContent,
+  ...Box.propTypes
 }
 
 export default Flex


### PR DESCRIPTION
First of all - thank you to all responsible for this library! Its amazing 

Currently I am wrapping the Flex component to avoid 'unknown props' warnings when I extend the Flex component (see [here](https://github.com/styled-components/styled-components/issues/439))

```
const flexProps = [...keys(FlexOriginal.propTypes), 'className']

export const Flex = styled(({ children, ...props }) => (
  <FlexOriginal { ...{ ...pick(props, flexProps) } }>
    {children}
  </FlexOriginal>
))
```

I am filtering out any unknown props before passing them to the Flex component. I have been making use of the `space` props extensively. Since the Box propTypes were being filtered it caused some issues...

Anyway, this should sort it out
