### PR TITLE
Reduce published package size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 package-lock.json
 coverage
 .nyc_output
+node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,9 @@
+src
 docs
 coverage
 .nyc_output
 test.js*
+.babelrc
+.travis.yml
+
+styled-space


### PR DESCRIPTION
After adding adding `grid-styled` to [opencollective/frontend](https://github.com/opencollective/frontend), we noticed the node_modules directory grew larger than expected.

Analysis graph from [Duc](http://duc.zevv.nl):
<img width="1066" alt="screen shot 2018-05-30 at 12 56 50 pm" src="https://user-images.githubusercontent.com/3051193/40735382-113dcea4-6409-11e8-8480-1b8a35fbe4ac.png">

With `styled-space` being included with the installation of `grid-styled`, the devDependencies for `styled-space` are installed. This includes everything from `styled-system`, i.e. the large `examples/` directory. 

This PR removes any file or directory not required for the published package to work:

- `src/`
- `styled-space/`
- `.babelrc`
- `travis.yml`

`node_modules` was also added to the `.gitignore` to prevent it being accidentally added when committing to this repo. 