### PR TITLE
Pin clean-tag to 1.0.3 to avoid incorrectly removed flexWrap and other tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "styled-components": ">=2.0 || >=3.0"
   },
   "dependencies": {
-    "clean-tag": "^1.0.3",
+    "clean-tag": "1.0.3",
     "styled-system": ">=2.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
This fixes issue #85, as `clean-tag@1.0.4` causes the following error when using the `flexWrap` property:

![screen shot 2018-06-14 at 2 01 39 pm](https://user-images.githubusercontent.com/1059075/41432368-7b890e08-6fdb-11e8-86d0-f90e5171dab9.png)
