### PR TITLE
Flex component should allow Box props when `is` prop is used

### DIFF
--- a/src/Flex.js
+++ b/src/Flex.js
@@ -1,14 +1,20 @@
+import styled from 'styled-components'
 import system from 'system-components'
 import Box from './Box'
 
-const Flex = system({
-  is: Box
-}, { display: 'flex' },
+const {
+  componentStyle: {
+    rules: flexRules
+  }
+} = system({},
+  { display: 'flex' },
   'flexWrap',
   'flexDirection',
   'alignItems',
   'justifyContent'
 )
+
+const Flex = styled(Box)([], ...flexRules);
 
 Flex.displayName = 'Flex'
 

--- a/tests/__snapshots__/index.js.snap
+++ b/tests/__snapshots__/index.js.snap
@@ -69,6 +69,41 @@ exports[`Flex renders 1`] = `
 />
 `;
 
+exports[`Flex renders with Box props 1`] = `
+.c1 {
+  box-sizing: border-box;
+  width: 100%;
+  margin: 4px;
+  padding-left: 4px;
+  padding-right: 4px;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+@media screen and (min-width:40em) {
+  .c1 {
+    margin: 8px;
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+}
+
+<footer
+  className="c0 c1"
+/>
+`;
+
 exports[`Flex renders with flexDirection prop 1`] = `
 .c1 {
   box-sizing: border-box;
@@ -86,6 +121,7 @@ exports[`Flex renders with flexDirection prop 1`] = `
 
 <div
   className="c0 c1"
+  flexDirection="column"
 />
 `;
 
@@ -116,7 +152,11 @@ exports[`Flex renders with legacy props 1`] = `
 }
 
 <div
+  align="center"
   className="c0 c1"
+  flexDirection="column"
+  justify="space-between"
+  wrap={true}
 />
 `;
 
@@ -147,7 +187,11 @@ exports[`Flex renders with props 1`] = `
 }
 
 <div
+  alignItems="center"
   className="c0 c1"
+  flexDirection="column"
+  flexWrap="wrap"
+  justifyContent="space-between"
 />
 `;
 
@@ -204,6 +248,30 @@ exports[`Flex renders with responsive props 1`] = `
 }
 
 <div
+  align={
+    Array [
+      "stretch",
+      "center",
+    ]
+  }
   className="c0 c1"
+  flexDirection={
+    Array [
+      "column",
+      "row",
+    ]
+  }
+  justify={
+    Array [
+      "space-between",
+      "center",
+    ]
+  }
+  wrap={
+    Array [
+      true,
+      false,
+    ]
+  }
 />
 `;

--- a/tests/index.js
+++ b/tests/index.js
@@ -40,6 +40,20 @@ test('Flex renders with props', () => {
   expect(json).toMatchSnapshot()
 })
 
+test('Flex renders with Box props', () => {
+  const json = renderJSON(
+    <Flex
+      is="footer"
+      m={[ 1, 2 ]}
+      px={[ 1, 2 ]}
+      w={1}
+      flex='1 1 auto'
+      alignSelf='flex-start'
+    />
+  )
+  expect(json).toMatchSnapshot()
+});
+
 test('Flex renders with legacy props', () => {
   const json = renderJSON(
     <Flex


### PR DESCRIPTION
Fixes #120 (potentially)

I've added a test for the use case of `<Flex is="footer" />` with a bunch of style props for the underlying Box component, as described by #120. The test case fails to create the Box style rules on the current release. 

I've figured out a _slight_ hack to still use `system-components` while using the `styled(Box)` factory to extend the Box component. This way the `is` prop can render different tags without breaking styles, however now Flex style props are rendered on the html element for some reason that I have not been able to figure out. 

I figure this should probably be a minor release bump at least since it will cause snapshots to break for folks using the library. 

Any feedback is very welcome. :smile: